### PR TITLE
PKG-3876: Build for python 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-3876](https://anaconda.atlassian.net/browse/PKG-3867) 

### Explanation of changes:

- Need to build for python 3.12. v3.5.0 is still the latest.
